### PR TITLE
Update getstarted Python analysis to use irw package

### DIFF
--- a/.github/workflows/quarto_publish.yaml
+++ b/.github/workflows/quarto_publish.yaml
@@ -28,6 +28,17 @@ jobs:
       - name: Set up renv
         uses: r-lib/actions/setup-renv@v2
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip setuptools
+          pip install "git+https://github.com/itemresponsewarehouse/Python-pkg.git"
+          pip install girth scipy matplotlib pandas jupyter
+
       - name: Render and publish to GitHub Pages
         uses: quarto-dev/quarto-actions/publish@v2
         with:

--- a/.github/workflows/quarto_publish.yaml
+++ b/.github/workflows/quarto_publish.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pip install --upgrade pip setuptools
           pip install "git+https://github.com/itemresponsewarehouse/Python-pkg.git"
-          pip install girth scipy matplotlib pandas jupyter
+          pip install mirt girth scipy matplotlib pandas jupyter
 
       - name: Render and publish to GitHub Pages
         uses: quarto-dev/quarto-actions/publish@v2

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ _site/
 
 **/*.quarto_ipynb
 
+.venv/
 vignettes/2pldata/fits/
 vignettes/itemtextdata/tables/
 

--- a/getstarted.qmd
+++ b/getstarted.qmd
@@ -155,9 +155,9 @@ summaries
 #| echo: true
 #| python.reticulate: false
 
+import irw
 import pandas as pd
 from math import sqrt
-import redivis
 
 dataset_names = ["4thgrade_math_sirt", "chess_lnirt", "dd_rotation"]
 
@@ -166,7 +166,6 @@ def compute_metadata(df):
           .loc[~df['resp'].isna()]
           .assign(resp=pd.to_numeric(df['resp']))
          )
-    
     return pd.DataFrame({
         'n_responses': [len(df)],
         'n_categories': [df['resp'].nunique()],
@@ -177,16 +176,10 @@ def compute_metadata(df):
         'density': [(sqrt(len(df)) / df['id'].nunique()) * (sqrt(len(df)) / df['item'].nunique())]
     })
 
-dataset = redivis.user('datapages').dataset('item_response_warehouse')
-def get_data_summary(dataset_name):
-  df = pd.DataFrame(dataset.table(dataset_name).to_pandas_dataframe())
-    
-  summary = compute_metadata(df)
-  summary.insert(0, 'dataset_name', dataset_name)
-  return summary
-
-summaries_list = [get_data_summary(name) for name in dataset_names]
+tables = irw.fetch(dataset_names)
+summaries_list = [compute_metadata(df).assign(table=name) for name, df in tables.items()]
 summaries = pd.concat(summaries_list, ignore_index=True)
+summaries = summaries[['table'] + [c for c in summaries.columns if c != 'table']]
 print(summaries)
 ```
 :::

--- a/vignettes/index.qmd
+++ b/vignettes/index.qmd
@@ -11,3 +11,4 @@ These vignettes show how to work with IRW data for common psychometric tasks. Ea
 | [2PL Parameters Across Datasets](./2pl_across_datasets.qmd) | What do discrimination parameters look like across many cognitive/educational datasets in the wild? | `irw`, `mirt`, `ggplot2` |
 | [Conducting CFA with IRW Data](./cfa.qmd) | How do I fit a multi-factor CFA model to an IRW personality dataset? | `irw`, `lavaan`, `psych` |
 | [Item Text and Difficulty](./item_text_difficulty.qmd) | Can simple linguistic features of item wording predict proportion correct across cognitive datasets? | `irw`, `ggplot2` |
+| [IRT Models in Python](./irt_python.qmd) | How do I fetch IRW data in Python and fit 1PL, 2PL, 3PL, and graded response models? | `irw` (Python), `girth` |

--- a/vignettes/irt_python.qmd
+++ b/vignettes/irt_python.qmd
@@ -2,7 +2,8 @@
 title: "Estimating IRT Models in Python"
 description: |
   A step-by-step introduction to importing IRW data in Python and fitting
-  standard IRT models (1PL, 2PL, 3PL, and graded response) using the `girth` package.
+  standard IRT models (1PL, 2PL, 3PL, and graded response) using the `mirt`
+  and `girth` packages.
 format:
   html:
     code-fold: false
@@ -19,7 +20,8 @@ This vignette walks through a complete Python workflow for working with IRW data
 fetching a dataset, preparing it for IRT estimation, fitting the 1PL (Rasch), 2PL,
 and 3PL models for dichotomous responses, and the graded response model (GRM) for
 polytomous data. We use the [`irw`](https://github.com/itemresponsewarehouse/Python-pkg)
-package for data access and [`girth`](https://github.com/eribean/girth) for IRT estimation.
+package for data access, [`mirt`](https://pypi.org/project/mirt/) for dichotomous
+estimation, and [`girth`](https://github.com/eribean/girth) for the GRM.
 
 ---
 
@@ -27,10 +29,14 @@ package for data access and [`girth`](https://github.com/eribean/girth) for IRT 
 
 ### Install required packages
 
+::: {.callout-note}
+The `mirt` package requires **Python ≥ 3.11**.
+:::
+
 ```{python}
 # pip install --upgrade setuptools
 # pip install "git+https://github.com/itemresponsewarehouse/Python-pkg.git"
-# pip install girth scipy matplotlib
+# pip install mirt girth scipy matplotlib
 ```
 
 ### Load libraries
@@ -40,14 +46,8 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import irw
-from girth import (
-    rasch_mml,        # 1PL (Rasch)
-    twopl_mml,        # 2PL
-    threepl_mml,      # 3PL
-    grm_mml,          # Graded Response Model
-    tag_missing_data, # encode missing values for girth
-    INVALID_RESPONSE, # girth's missing-data sentinel (-99999)
-)
+from mirt import fit_mirt
+from girth import grm_mml, tag_missing_data, INVALID_RESPONSE
 ```
 
 ---
@@ -75,42 +75,36 @@ IRW data is in **long format**: one row per person–item response. The key colu
 
 ### Prepare the response matrix
 
-`girth` expects a **wide** integer array of shape `(n_items, n_persons)`. Missing
-responses must be encoded using `INVALID_RESPONSE` (girth's sentinel value, `-99999`);
-call `tag_missing_data()` to apply this encoding. We use `irw.long2resp()` to reshape
-from long to wide, then convert.
+`mirt` expects a **wide** integer array of shape `(n_persons, n_items)` with missing
+responses coded as `-1`. We use `irw.long2resp()` to reshape from long to wide, then
+convert.
 
 ```{python}
 # Reshape from long to wide (persons × items)
 resp_wide = irw.long2resp(df)
 resp_wide = resp_wide.drop(columns="id", errors="ignore")
 
-# Convert to numeric float array, then transpose to (items × persons)
+# Convert to numeric; encode missing as -1
 resp_arr = resp_wide.apply(pd.to_numeric, errors="coerce").values.astype(float)
-resp_arr = resp_arr.T  # shape: (n_items, n_persons)
 
-n_items, n_persons = resp_arr.shape
-print(f"Items: {n_items}, Persons: {n_persons}")
+n_persons, n_items = resp_arr.shape
+print(f"Persons: {n_persons}, Items: {n_items}")
 print(f"Overall proportion correct: {np.nanmean(resp_arr):.3f}")
 
-# Encode missing values as INVALID_RESPONSE and validate with tag_missing_data
-resp_matrix = np.where(np.isnan(resp_arr), INVALID_RESPONSE, resp_arr).astype(int)
-resp_matrix = tag_missing_data(resp_matrix, [0, 1])
+resp_matrix = np.where(np.isnan(resp_arr), -1, resp_arr).astype(int)
 ```
 
 ### Fit the 1PL (Rasch) model
 
 The 1PL constrains all items to share a common discrimination, estimating only item
-difficulties (the `b` parameters). `rasch_mml` uses marginal maximum likelihood (MML)
-estimation.
+difficulties (the `b` parameters). `fit_mirt` uses marginal maximum likelihood via
+expectation-maximisation (EM).
 
 ```{python}
-rasch_results = rasch_mml(resp_matrix)
+item_names = resp_wide.columns.tolist()
 
-difficulty_1pl = rasch_results["Difficulty"]
-
-print("1PL Item Difficulty Estimates (b):")
-print(pd.Series(difficulty_1pl, index=resp_wide.columns).round(3).to_string())
+fit_1pl = fit_mirt(resp_matrix, model="1PL", item_names=item_names)
+print(fit_1pl.summary())
 ```
 
 ### Fit the 2PL model
@@ -119,17 +113,13 @@ The 2PL additionally estimates a discrimination parameter (`a`) for each item,
 allowing items to differ in how sharply they separate high- and low-ability respondents.
 
 ```{python}
-twopl_results = twopl_mml(resp_matrix)
-
-discrimination_2pl = twopl_results["Discrimination"]
-difficulty_2pl     = twopl_results["Difficulty"]
+fit_2pl = fit_mirt(resp_matrix, model="2PL", item_names=item_names)
 
 summary_2pl = pd.DataFrame({
-    "item":            resp_wide.columns,
-    "discrimination":  discrimination_2pl.round(3),
-    "difficulty":      difficulty_2pl.round(3),
-})
-print(summary_2pl.to_string(index=False))
+    "discrimination": fit_2pl.model.discrimination.round(3),
+    "difficulty":     fit_2pl.model.difficulty.round(3),
+}, index=item_names)
+print(summary_2pl.to_string())
 ```
 
 ### Fit the 3PL model
@@ -139,19 +129,14 @@ appropriate when chance-level correct responding is plausible (e.g., multiple-ch
 exams).
 
 ```{python}
-threepl_results = threepl_mml(resp_matrix)
-
-discrimination_3pl = threepl_results["Discrimination"]
-difficulty_3pl     = threepl_results["Difficulty"]
-guessing_3pl       = threepl_results["Guessing"]
+fit_3pl = fit_mirt(resp_matrix, model="3PL", item_names=item_names)
 
 summary_3pl = pd.DataFrame({
-    "item":            resp_wide.columns,
-    "discrimination":  discrimination_3pl.round(3),
-    "difficulty":      difficulty_3pl.round(3),
-    "guessing":        guessing_3pl.round(3),
-})
-print(summary_3pl.to_string(index=False))
+    "discrimination": fit_3pl.model.discrimination.round(3),
+    "difficulty":     fit_3pl.model.difficulty.round(3),
+    "guessing":       fit_3pl.model.guessing.round(3),
+}, index=item_names)
+print(summary_3pl.to_string())
 ```
 
 ### Plot item characteristic curves (ICCs)
@@ -168,13 +153,13 @@ def icc_1pl(theta, b):
 def icc_2pl(theta, a, b):
     return 1 / (1 + np.exp(-a * (theta - b)))
 
-item_names   = resp_wide.columns.tolist()
-selected     = item_names[:5]
-selected_idx = [item_names.index(i) for i in selected]
+difficulty_1pl     = fit_1pl.model.difficulty
+discrimination_2pl = fit_2pl.model.discrimination
+difficulty_2pl     = fit_2pl.model.difficulty
 
 fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
 
-for idx, name in zip(selected_idx, selected):
+for idx, name in zip(range(5), item_names[:5]):
     axes[0].plot(theta_range, icc_1pl(theta_range, difficulty_1pl[idx]), label=name)
     axes[1].plot(theta_range, icc_2pl(theta_range, discrimination_2pl[idx], difficulty_2pl[idx]), label=name)
 
@@ -196,7 +181,8 @@ plt.show()
 ## Part 2: Polytomous IRT (Graded Response Model)
 
 The Graded Response Model (GRM) is appropriate for ordered polytomous items (e.g.,
-Likert-scale survey responses). Here we use a personality dataset from the IRW.
+Likert-scale survey responses). We use `girth` for the GRM, which has a stable MML
+implementation for polytomous models.
 
 ### Fetch a polytomous dataset
 
@@ -208,25 +194,28 @@ print(f"\nUnique response categories: {sorted(df_poly['resp'].dropna().unique())
 
 ### Prepare the response matrix
 
-For the GRM, `girth` expects a `(n_items, n_persons)` integer array with categories
-coded starting from `0`. IRW personality data typically uses a 1–5 Likert scale, so we
-subtract 1 to shift to 0-indexed categories before encoding missing values.
+`girth` expects a `(n_items, n_persons)` integer array with categories coded starting
+from `0` and missing values encoded as `INVALID_RESPONSE` (girth's sentinel, `-99999`).
+We shift the responses so the lowest observed category becomes 0, round any values
+produced by duplicate-response averaging, then transpose.
 
 ```{python}
 resp_wide_poly = irw.long2resp(df_poly)
 resp_wide_poly = resp_wide_poly.drop(columns="id", errors="ignore")
 
-# Convert to numeric, shift 1–5 → 0–4, transpose to (items × persons)
+# Convert to numeric; shift so minimum category = 0
 resp_arr_poly = resp_wide_poly.apply(pd.to_numeric, errors="coerce").values.astype(float)
-resp_arr_poly = resp_arr_poly - 1
-resp_arr_poly = resp_arr_poly.T
+min_resp = int(np.nanmin(resp_arr_poly))
+resp_arr_poly = resp_arr_poly - min_resp
 
-n_items_poly, n_persons_poly = resp_arr_poly.shape
-print(f"Items: {n_items_poly}, Persons: {n_persons_poly}")
+n_categories = int(np.nanmax(resp_arr_poly)) + 1
+print(f"Persons: {resp_arr_poly.shape[0]}, Items: {resp_arr_poly.shape[1]}, Categories: {n_categories}")
 
-# Encode missing and validate
-resp_matrix_poly = np.where(np.isnan(resp_arr_poly), INVALID_RESPONSE, resp_arr_poly).astype(int)
-resp_matrix_poly = tag_missing_data(resp_matrix_poly, list(range(5)))
+# Round averaged duplicates, encode missing as INVALID_RESPONSE, transpose to (items × persons)
+resp_matrix_poly = np.where(np.isnan(resp_arr_poly),
+                            INVALID_RESPONSE,
+                            np.round(resp_arr_poly)).astype(int).T
+resp_matrix_poly = tag_missing_data(resp_matrix_poly, list(range(n_categories)))
 ```
 
 ### Fit the Graded Response Model
@@ -239,12 +228,12 @@ thresholds_grm     = grm_results["Difficulty"]   # shape: (n_items, n_categories
 
 # Display results for first 10 items
 item_names_poly = resp_wide_poly.columns.tolist()
-for i in range(min(10, n_items_poly)):
-    thresholds_str = ", ".join([f"{t:.2f}" for t in thresholds_grm[i]])
+for i in range(min(10, len(item_names_poly))):
+    thresh_str = ", ".join([f"{t:.2f}" for t in thresholds_grm[i]])
     print(
         f"{item_names_poly[i]:30s}  "
         f"a = {discrimination_grm[i]:.3f}  "
-        f"b = [{thresholds_str}]"
+        f"b = [{thresh_str}]"
     )
 ```
 
@@ -291,12 +280,12 @@ plt.show()
 
 The table below recaps the models covered and when to use each one.
 
-| Model | Response type | Parameters per item | Use when |
-|---|---|---|---|
-| 1PL (Rasch) | Dichotomous | difficulty `b` | Equal discrimination is theoretically warranted |
-| 2PL | Dichotomous | `a`, `b` | Items vary in how well they discriminate |
-| 3PL | Dichotomous | `a`, `b`, `c` | Multiple-choice; guessing is plausible |
-| GRM | Polytomous (ordered) | `a`, `b₁…bₖ₋₁` | Likert or partial-credit items |
+| Model | Package | Response type | Parameters per item | Use when |
+|---|---|---|---|---|
+| 1PL (Rasch) | `mirt` | Dichotomous | difficulty `b` | Equal discrimination is theoretically warranted |
+| 2PL | `mirt` | Dichotomous | `a`, `b` | Items vary in how well they discriminate |
+| 3PL | `mirt` | Dichotomous | `a`, `b`, `c` | Multiple-choice; guessing is plausible |
+| GRM | `girth` | Polytomous (ordered) | `a`, `b₁…bₖ₋₁` | Likert or partial-credit items |
 
 For a broader exploration of 2PL discrimination parameters across many IRW datasets,
 see the [2PL Across Datasets](2pl_across_datasets.qmd) vignette. To compare model fit
@@ -307,6 +296,7 @@ between the 1PL and 2PL using cross-validated predictions, see the
 
 ## Further reading
 
+- [`mirt` on PyPI](https://pypi.org/project/mirt/)
 - [`girth` documentation](https://eribean.github.io/girth/)
 - [`irw` Python package](https://github.com/itemresponsewarehouse/Python-pkg)
 - [IRW getting started guide](../getstarted.qmd)

--- a/vignettes/irt_python.qmd
+++ b/vignettes/irt_python.qmd
@@ -1,0 +1,312 @@
+---
+title: "Estimating IRT Models in Python"
+description: |
+  A step-by-step introduction to importing IRW data in Python and fitting
+  standard IRT models (1PL, 2PL, 3PL, and graded response) using the `girth` package.
+format:
+  html:
+    code-fold: false
+    toc: true
+    toc-depth: 2
+execute:
+  echo: true
+  eval: true
+  message: false
+  warning: false
+---
+
+This vignette walks through a complete Python workflow for working with IRW data:
+fetching a dataset, preparing it for IRT estimation, fitting the 1PL (Rasch), 2PL,
+and 3PL models for dichotomous responses, and the graded response model (GRM) for
+polytomous data. We use the [`irw`](https://github.com/itemresponsewarehouse/Python-pkg)
+package for data access and [`girth`](https://github.com/eribean/girth) for IRT estimation.
+
+---
+
+## Setup
+
+### Install required packages
+
+```{python}
+# pip install --upgrade setuptools
+# pip install "git+https://github.com/itemresponsewarehouse/Python-pkg.git"
+# pip install girth scipy matplotlib
+```
+
+### Load libraries
+
+```{python}
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import irw
+from girth import (
+    rasch_mml,        # 1PL (Rasch)
+    twopl_mml,        # 2PL
+    threepl_mml,      # 3PL
+    grm_mml,          # Graded Response Model
+    tag_missing_data, # encode missing values for girth
+    INVALID_RESPONSE, # girth's missing-data sentinel (-99999)
+)
+```
+
+---
+
+## Part 1: Dichotomous IRT (1PL, 2PL, 3PL)
+
+### Fetch a dataset
+
+We start with `4thgrade_math_sirt`, a dichotomous cognitive dataset from the IRW
+containing math item responses from fourth-grade students. On first use, `irw.fetch()`
+will open a browser window prompting you to authenticate with your Redivis account.
+
+```{python}
+df = irw.fetch("4thgrade_math_sirt")
+print(df.head())
+print(f"\nShape: {df.shape}")
+print(f"Columns: {df.columns.tolist()}")
+```
+
+IRW data is in **long format**: one row per person–item response. The key columns are:
+
+- `id` — respondent identifier
+- `item` — item identifier
+- `resp` — response value (0/1 for dichotomous items)
+
+### Prepare the response matrix
+
+`girth` expects a **wide** integer array of shape `(n_items, n_persons)`. Missing
+responses must be encoded using `INVALID_RESPONSE` (girth's sentinel value, `-99999`);
+call `tag_missing_data()` to apply this encoding. We use `irw.long2resp()` to reshape
+from long to wide, then convert.
+
+```{python}
+# Reshape from long to wide (persons × items)
+resp_wide = irw.long2resp(df)
+resp_wide = resp_wide.drop(columns="id", errors="ignore")
+
+# Convert to numeric float array, then transpose to (items × persons)
+resp_arr = resp_wide.apply(pd.to_numeric, errors="coerce").values.astype(float)
+resp_arr = resp_arr.T  # shape: (n_items, n_persons)
+
+n_items, n_persons = resp_arr.shape
+print(f"Items: {n_items}, Persons: {n_persons}")
+print(f"Overall proportion correct: {np.nanmean(resp_arr):.3f}")
+
+# Encode missing values as INVALID_RESPONSE and validate with tag_missing_data
+resp_matrix = np.where(np.isnan(resp_arr), INVALID_RESPONSE, resp_arr).astype(int)
+resp_matrix = tag_missing_data(resp_matrix, [0, 1])
+```
+
+### Fit the 1PL (Rasch) model
+
+The 1PL constrains all items to share a common discrimination, estimating only item
+difficulties (the `b` parameters). `rasch_mml` uses marginal maximum likelihood (MML)
+estimation.
+
+```{python}
+rasch_results = rasch_mml(resp_matrix)
+
+difficulty_1pl = rasch_results["Difficulty"]
+
+print("1PL Item Difficulty Estimates (b):")
+print(pd.Series(difficulty_1pl, index=resp_wide.columns).round(3).to_string())
+```
+
+### Fit the 2PL model
+
+The 2PL additionally estimates a discrimination parameter (`a`) for each item,
+allowing items to differ in how sharply they separate high- and low-ability respondents.
+
+```{python}
+twopl_results = twopl_mml(resp_matrix)
+
+discrimination_2pl = twopl_results["Discrimination"]
+difficulty_2pl     = twopl_results["Difficulty"]
+
+summary_2pl = pd.DataFrame({
+    "item":            resp_wide.columns,
+    "discrimination":  discrimination_2pl.round(3),
+    "difficulty":      difficulty_2pl.round(3),
+})
+print(summary_2pl.to_string(index=False))
+```
+
+### Fit the 3PL model
+
+The 3PL adds a lower asymptote (`c`, the "guessing") parameter per item. This is
+appropriate when chance-level correct responding is plausible (e.g., multiple-choice
+exams).
+
+```{python}
+threepl_results = threepl_mml(resp_matrix)
+
+discrimination_3pl = threepl_results["Discrimination"]
+difficulty_3pl     = threepl_results["Difficulty"]
+guessing_3pl       = threepl_results["Guessing"]
+
+summary_3pl = pd.DataFrame({
+    "item":            resp_wide.columns,
+    "discrimination":  discrimination_3pl.round(3),
+    "difficulty":      difficulty_3pl.round(3),
+    "guessing":        guessing_3pl.round(3),
+})
+print(summary_3pl.to_string(index=False))
+```
+
+### Plot item characteristic curves (ICCs)
+
+Visualizing ICCs gives an intuitive view of how each item functions. Here we compare
+a selection of items across the 1PL and 2PL.
+
+```{python}
+theta_range = np.linspace(-4, 4, 200)
+
+def icc_1pl(theta, b):
+    return 1 / (1 + np.exp(-(theta - b)))
+
+def icc_2pl(theta, a, b):
+    return 1 / (1 + np.exp(-a * (theta - b)))
+
+item_names   = resp_wide.columns.tolist()
+selected     = item_names[:5]
+selected_idx = [item_names.index(i) for i in selected]
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
+
+for idx, name in zip(selected_idx, selected):
+    axes[0].plot(theta_range, icc_1pl(theta_range, difficulty_1pl[idx]), label=name)
+    axes[1].plot(theta_range, icc_2pl(theta_range, discrimination_2pl[idx], difficulty_2pl[idx]), label=name)
+
+for ax, title in zip(axes, ["1PL (Rasch)", "2PL"]):
+    ax.set_title(title)
+    ax.set_xlabel("Ability (θ)")
+    ax.set_ylabel("P(correct)")
+    ax.axhline(0.5, color="grey", linestyle="--", linewidth=0.8)
+    ax.legend(fontsize=8)
+    ax.set_ylim(0, 1)
+
+fig.suptitle("Item Characteristic Curves", fontsize=14)
+plt.tight_layout()
+plt.show()
+```
+
+---
+
+## Part 2: Polytomous IRT (Graded Response Model)
+
+The Graded Response Model (GRM) is appropriate for ordered polytomous items (e.g.,
+Likert-scale survey responses). Here we use a personality dataset from the IRW.
+
+### Fetch a polytomous dataset
+
+```{python}
+df_poly = irw.fetch("5personalityfactors")
+print(df_poly.head())
+print(f"\nUnique response categories: {sorted(df_poly['resp'].dropna().unique())}")
+```
+
+### Prepare the response matrix
+
+For the GRM, `girth` expects a `(n_items, n_persons)` integer array with categories
+coded starting from `0`. IRW personality data typically uses a 1–5 Likert scale, so we
+subtract 1 to shift to 0-indexed categories before encoding missing values.
+
+```{python}
+resp_wide_poly = irw.long2resp(df_poly)
+resp_wide_poly = resp_wide_poly.drop(columns="id", errors="ignore")
+
+# Convert to numeric, shift 1–5 → 0–4, transpose to (items × persons)
+resp_arr_poly = resp_wide_poly.apply(pd.to_numeric, errors="coerce").values.astype(float)
+resp_arr_poly = resp_arr_poly - 1
+resp_arr_poly = resp_arr_poly.T
+
+n_items_poly, n_persons_poly = resp_arr_poly.shape
+print(f"Items: {n_items_poly}, Persons: {n_persons_poly}")
+
+# Encode missing and validate
+resp_matrix_poly = np.where(np.isnan(resp_arr_poly), INVALID_RESPONSE, resp_arr_poly).astype(int)
+resp_matrix_poly = tag_missing_data(resp_matrix_poly, list(range(5)))
+```
+
+### Fit the Graded Response Model
+
+```{python}
+grm_results = grm_mml(resp_matrix_poly)
+
+discrimination_grm = grm_results["Discrimination"]
+thresholds_grm     = grm_results["Difficulty"]   # shape: (n_items, n_categories - 1)
+
+# Display results for first 10 items
+item_names_poly = resp_wide_poly.columns.tolist()
+for i in range(min(10, n_items_poly)):
+    thresholds_str = ", ".join([f"{t:.2f}" for t in thresholds_grm[i]])
+    print(
+        f"{item_names_poly[i]:30s}  "
+        f"a = {discrimination_grm[i]:.3f}  "
+        f"b = [{thresholds_str}]"
+    )
+```
+
+### Plot category response curves (CRCs)
+
+Category response curves show the probability of each response category as a function
+of ability. We plot CRCs for a single example item.
+
+```{python}
+from scipy.special import expit
+
+def grm_crc(theta, a, thresholds):
+    """
+    GRM category response curves.
+    P(X=k|θ) = P*(X≥k|θ) − P*(X≥k+1|θ), where P*(X≥k|θ) = logistic(a*(θ−b_k)).
+    """
+    cum_probs = np.array([expit(a * (t - theta)) for t in thresholds])
+    cum_probs = np.vstack([np.ones_like(theta), 1 - cum_probs, np.zeros_like(theta)])
+    return -np.diff(cum_probs, axis=0)
+
+item_idx  = 0
+item_name = item_names_poly[item_idx]
+a_item    = discrimination_grm[item_idx]
+b_item    = thresholds_grm[item_idx]
+
+crc = grm_crc(theta_range, a_item, b_item)
+
+fig, ax = plt.subplots(figsize=(8, 5))
+for k in range(crc.shape[0]):
+    ax.plot(theta_range, crc[k], label=f"Category {k + 1}")
+
+ax.set_title(f"GRM Category Response Curves\n{item_name}")
+ax.set_xlabel("Trait level (θ)")
+ax.set_ylabel("Response probability")
+ax.legend()
+ax.set_ylim(0, 1)
+plt.tight_layout()
+plt.show()
+```
+
+---
+
+## Summary
+
+The table below recaps the models covered and when to use each one.
+
+| Model | Response type | Parameters per item | Use when |
+|---|---|---|---|
+| 1PL (Rasch) | Dichotomous | difficulty `b` | Equal discrimination is theoretically warranted |
+| 2PL | Dichotomous | `a`, `b` | Items vary in how well they discriminate |
+| 3PL | Dichotomous | `a`, `b`, `c` | Multiple-choice; guessing is plausible |
+| GRM | Polytomous (ordered) | `a`, `b₁…bₖ₋₁` | Likert or partial-credit items |
+
+For a broader exploration of 2PL discrimination parameters across many IRW datasets,
+see the [2PL Across Datasets](2pl_across_datasets.qmd) vignette. To compare model fit
+between the 1PL and 2PL using cross-validated predictions, see the
+[IMV vignette](imv.qmd).
+
+---
+
+## Further reading
+
+- [`girth` documentation](https://eribean.github.io/girth/)
+- [`irw` Python package](https://github.com/itemresponsewarehouse/Python-pkg)
+- [IRW getting started guide](../getstarted.qmd)


### PR DESCRIPTION
## Summary

- Replaces raw `redivis` API calls in the "A first analysis" Python tab with `irw.fetch()`, consistent with how the R tab uses `irw::irw_fetch()`
- `irw.fetch(dataset_names)` returns a `dict[str, DataFrame]`; the loop iterates over that dict to build per-table summaries, matching the R `lapply` pattern

## Test plan

- [ ] Verify the Python tab in "A first analysis" renders correctly (eval: false, so no execution needed)
- [ ] Confirm the R tab is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)