### PR TITLE
Misc page improvements: Python tab, stale text, typo fixes

### DIFF
--- a/contribute.qmd
+++ b/contribute.qmd
@@ -7,21 +7,21 @@ We welcome contribution of new datasets to the IRW!
 
 ## Contributing data
 
-#### If you would like to contribute data, **please feel out the (brief) form [here](https://forms.gle/DaTKe2bpZw3vZqj77)**.
+#### If you would like to contribute data, **please fill out the (brief) form [here](https://forms.gle/DaTKe2bpZw3vZqj77)**.
 
-We will take information about any data that you think may be worth including in the IRW. Inclusion will be easier if the data is already in a format consistent with the [IRW data standard](standard.qmd). Below we preovide information on how to construct such a dataset.
+We will take information about any data that you think may be worth including in the IRW. Inclusion will be easier if the data is already in a format consistent with the [IRW data standard](standard.qmd). Below we provide information on how to construct such a dataset.
 
 ## Constructing an IRW-compliant dataset
 
-Below are critical instructions for formatting data for the IRW. More details are available [here](standard.qmd). . 
+Below are critical instructions for formatting data for the IRW. More details are available [here](standard.qmd).
 
 1. Numeric values of a response should be meaningful. For example, missing values cannot be coded as numbers (e.g., -9).
 
 2. Please check that the `id` and `item` identifers have an appropriate number of unique values.
 
-3. Additional data elements (e.g., `rt`, `date`, `wave`, `rater`, `qmatrix`) should all be formatted as specified above. 
+3. Additional data elements (e.g., `rt`, `date`, `wave`, `rater`, `qmatrix`) should all be formatted as specified above.
 
-4. If there are multiple scales available, the responses need to be split into mutiple files (one per scale). If multiple groups are assessed via the same scale, these data can be put into a single file (if desired, a column indicating group membership can be added).
+4. If there are multiple scales available, the responses need to be split into multiple files (one per scale). If multiple groups are assessed via the same scale, these data can be put into a single file (if desired, a column indicating group membership can be added).
 
-While we have tried to offer generic guidance on formatting data to the IRW standard, there are innumerable idiosyncracies that may merit additional conversation. To discuss specific  issues associated with your formatting your data to the IRW standard, please feel free to each out to us at `itemresponsewarehouse@stanford.edu`. We would be happy to talk more! You can also use the [IRW Dataset Builder](https://irw-dataset-builder.streamlit.app/) that will help port data to the IRW data standard if you like. 
+While we have tried to offer generic guidance on formatting data to the IRW standard, there are innumerable idiosyncrasies that may merit additional conversation. To discuss specific issues associated with formatting your data to the IRW standard, please feel free to reach out to us at `itemresponsewarehouse@stanford.edu`. We would be happy to talk more! You can also use the [IRW Dataset Builder](https://irw-dataset-builder.streamlit.app/) that will help port data to the IRW data standard if you like.
 

--- a/itemtext_merge.qmd
+++ b/itemtext_merge.qmd
@@ -24,6 +24,7 @@ head(df)
 
 ```{python}
 #| echo: true
+#| python.reticulate: false
 import irw
 import pandas as pd
 

--- a/itemtext_merge.qmd
+++ b/itemtext_merge.qmd
@@ -23,9 +23,7 @@ head(df)
 ## Python
 
 ```{python}
-#| eval: false
 #| echo: true
-#| python.reticulate: false
 import irw
 import pandas as pd
 

--- a/itemtext_merge.qmd
+++ b/itemtext_merge.qmd
@@ -23,6 +23,7 @@ head(df)
 ## Python
 
 ```{python}
+#| eval: false
 #| echo: true
 #| python.reticulate: false
 import irw

--- a/itemtext_merge.qmd
+++ b/itemtext_merge.qmd
@@ -19,6 +19,21 @@ df<-irw::irw_fetch("gilbert_meta_49")
 df<-merge(items,df)
 head(df)
 ```
+
+## Python
+
+```{python}
+#| eval: false
+#| echo: true
+#| python.reticulate: false
+import irw
+import pandas as pd
+
+items = irw.itemtext("gilbert_meta_49")
+df = irw.fetch("gilbert_meta_49")
+merged = pd.merge(items, df, on=["table", "item"])
+print(merged.head())
+```
 :::
 
 Merging these datasets allows for a more complete view of the data, including:

--- a/problems.qmd
+++ b/problems.qmd
@@ -26,7 +26,7 @@ We are going to start thinking about IRT models next week and I wanted to begin 
 
 ### A comparison of the 1-3PL approaches.
 
-The 1PL, 2PL, and 3PL are all commonly used with dichotomous responses. We can examine the differences in the estimated response funtions for each of these models when applied to data from the Brazilian ENEM assessment, see [here](https://github.com/ben-domingue/252/blob/main/c4/enem1.R). What do you think of the differences between the approaches? 
+The 1PL, 2PL, and 3PL are all commonly used with dichotomous responses. We can examine the differences in the estimated response functions for each of these models when applied to data from the Brazilian ENEM assessment, see [here](https://github.com/ben-domingue/252/blob/main/c4/enem1.R). What do you think of the differences between the approaches? 
 
 ### Predictions
 
@@ -44,7 +44,7 @@ Priors can be very useful for IRT item parameters especially if you have smaller
 An example of how to impose priors on the discrimination and guessing parameters can be found [here](https://github.com/ben-domingue/252/blob/main/ps4/priors.R). From whatever perspective you like (parameter estimates, predictions as in #2; feel free to find some different data that lead to more dramatic differences!), consider the implications of adding priors to analysis of some item response data. I have added a small example illustrating how item parameter estimates differ with and without priors. Feel free to build on this in any way you like—for example, by examining whether including priors improves predictive performance.
 
 
-### Measurement invariancce and item text
+### Measurement invariance and item text
 
 We are adding item text to the IRW. We are going to take advantage of that now to probe for DIF. We are going to look at data from the `gilbert_meta_11` RCT and assess whether there is any DIF in the items as a function of respondent features. 
 

--- a/training.qmd
+++ b/training.qmd
@@ -20,7 +20,7 @@ The data are structured in an Item Response Warehouse (IRW)-consistent format (m
 
 The H&F data for the competition were collected from a large urban district in the US. In particular, these data were collected in school environments. Students completed the Hearts and Flowers measures on digital devices during the school day.
 
-The data are available here [to be posted June 9 2025].
+The data are available here:
 
 * [Training data](https://www.dropbox.com/scl/fi/ofve08sfpkkfcw4fba258/imps2025_train.csv?rlkey=p3to1voy2ughnzoxv1nmbl7q7&e=1&st=skp9kftd&dl=0)
 * [Test data](https://www.dropbox.com/scl/fi/2xjpxdjzme9quzvfpsjgw/imps2025_test.csv?rlkey=z5rn1bv1qnoetg9ksmrr12u9l&e=1&st=eyrbel9y&dl=0)


### PR DESCRIPTION
## Summary

- **`itemtext_merge.qmd`**: adds Python tab with `irw.itemtext()` + `irw.fetch()` + `pd.merge()`, parallel to the existing R tab
- **`training.qmd`**: removes stale `[to be posted June 9 2025]` placeholder (data links were already present)
- **`contribute.qmd`**: fixes five errors — "feel out" → "fill out", "preovide" → "provide", double period, "mutiple" → "multiple", "each out" → "reach out"
- **`problems.qmd`**: fixes two typos — "funtions" → "functions", "Measurement invariancce" → "Measurement invariance"

## Test plan

- [ ] Check `itemtext_merge.qmd` renders with both R and Python tabs visible
- [ ] Verify `training.qmd` data section reads cleanly
- [ ] Spot-check `contribute.qmd` and `problems.qmd` for corrected text

🤖 Generated with [Claude Code](https://claude.com/claude-code)