### PR TITLE
Expand simsyn page, fix typo and stale link

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -8,7 +8,7 @@ title: "About"
 
 * **A [manuscript](https://link.springer.com/article/10.3758/s13428-025-02796-y) describing the IRW is available.**
 
-* [This website](https://github.com/langcog/irw_site) is made using:
+* [This website](https://github.com/datapages/irw) is made using:
   + [Quarto](https://quarto.org/),
   + with interactive visualizations in [Observable](https://observablehq.com/),
   + and hosted on [GitHub pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages).

--- a/simsyn.qmd
+++ b/simsyn.qmd
@@ -2,8 +2,48 @@
 title: "Simulated and synthetic (simsyn) data"
 ---
 
-These data are simulated (according to some statistical model) or synthetic (so that they are meant to approximate a specific real dataset) but are otherwise in the IRW data standard.
+The IRW includes a branch of **simulated and synthetic** item response datasets, collectively referred to as *simsyn*. These data follow the same [IRW data standard](standard.qmd) as the core repository and can be accessed using the same `irw` package functions, with `source = "sim"`.
+
+- **Simulated** data are generated from a statistical model (e.g., a Rasch or 2PL model) with known parameter values. They are useful for methods development, power analysis, and verifying that estimation procedures recover the true parameters.
+
+- **Synthetic** data are constructed to approximate the properties of a specific real dataset — preserving features like the number of respondents, items, and response distributions — while protecting privacy or enabling open sharing where the original cannot be released.
 
 ## Accessing the simsyn data
 
-Documentation related to the tables can be found [here](https://docs.google.com/spreadsheets/d/1_2SR1_miAqUy0HWFQqo5vrBVrIN4V1FU6RfavBc7WdA/edit?gid=1337607315#gid=1337607315).
+Documentation for the available tables can be found [here](https://docs.google.com/spreadsheets/d/1_2SR1_miAqUy0HWFQqo5vrBVrIN4V1FU6RfavBc7WdA/edit?gid=1337607315#gid=1337607315).
+
+::: panel-tabset
+## R
+
+```{r}
+#| eval: false
+#| echo: true
+library(irw)
+
+tables <- irw_list_tables(source = "sim")     # List available simsyn tables
+df <- irw_fetch(tables$name[1], source = "sim") # Fetch a simsyn table
+```
+
+## Python
+
+```{python}
+#| eval: false
+#| echo: true
+#| python.reticulate: false
+import irw
+
+tables = irw.list_tables(source="sim")        # List available simsyn tables
+df = irw.fetch(tables["name"].iloc[0], source="sim")  # Fetch a simsyn table
+```
+:::
+
+## Use cases
+
+Simsyn data are particularly useful when you want to:
+
+- **Benchmark estimation methods** against data with known ground-truth parameters
+- **Develop or test new psychometric approaches** without relying on real participants
+- **Reproduce analyses** from published work that used proprietary data, via a synthetic stand-in
+- **Teach** IRT concepts using data that behave predictably under a given model
+
+For realistic simulation of item difficulty parameters informed by the empirical IRW distribution, see the [Simulating Item Difficulties](vignettes/diffsim.qmd) vignette.

--- a/standard.qmd
+++ b/standard.qmd
@@ -17,7 +17,7 @@ The below three features are essential components of an IRW dataset (with some s
 
   + Response values that were imputed in the original data have been removed. 
 
-  + Within an item, values are meant to be consistently coded so that higher numbers indicate a consistently meanginful change in a response (i.e., higher numbers indicate stronger agreement). However, values may load on the latent variable in opposite ways across items (i.e., higher numbers may indicate strong agreement for some items and weaker agreement for others). 
+  + Within an item, values are meant to be consistently coded so that higher numbers indicate a consistently meaningful change in a response (i.e., higher numbers indicate stronger agreement). However, values may load on the latent variable in opposite ways across items (i.e., higher numbers may indicate strong agreement for some items and weaker agreement for others). 
 
 ## Other elements
 


### PR DESCRIPTION
## Summary

- **`simsyn.qmd`**: expanded from two sentences to a full page — explains simulated vs synthetic distinction, adds R/Python access examples with `source="sim"`, and a use-cases section linking to the diffsim vignette
- **`standard.qmd`**: fix typo "meanginful" → "meaningful"
- **`about.qmd`**: update website repo link from stale `langcog/irw_site` to `datapages/irw`

## Test plan

- [ ] Verify `simsyn.qmd` renders cleanly (all code blocks are `eval: false`)
- [ ] Check `standard.qmd` typo fix
- [ ] Confirm `about.qmd` link points to correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)