### PR TITLE
Add third IRW Redivis dataset and update packages

### DIFF
--- a/_load-data-explore.qmd
+++ b/_load-data-explore.qmd
@@ -102,7 +102,7 @@ tag_vals <- tags |>
   select(-values) |>
   deframe()
 
-ds <- c("item_response_warehouse", "item_response_warehouse_2")
+ds <- c("item_response_warehouse", "item_response_warehouse_2", "item_response_warehouse_3")
 urls <- ds |>
   map(\(d) redivis$user("datapages")$dataset(d)$list_tables() |>
         map(\(t) tibble(table = t$name, url = t$properties$url)) |>

--- a/_load-data.qmd
+++ b/_load-data.qmd
@@ -26,7 +26,23 @@ data_index <- biblio |>
   mutate(dataset = str_remove(dataset, ".R.ata$")) |>
   arrange(dataset)
 
-# Make it available to OJS 
+# Make it available to OJS
 ojs_define(data_index = data_index)
+
+# Build table → Redivis dataset reference map for embed URL construction
+irw_ds <- list(
+  list(name = "item_response_warehouse",   ref = "item_response_warehouse:as2e"),
+  list(name = "item_response_warehouse_2", ref = "item_response_warehouse_2:epbx"),
+  list(name = "item_response_warehouse_3", ref = "item_response_warehouse_3:5xaj")
+)
+table_ds_ref <- do.call(rbind, lapply(irw_ds, function(ds) {
+  tabs <- redivis$user("datapages")$dataset(ds$name)$list_tables()
+  data.frame(
+    table   = tolower(sapply(tabs, function(t) t$name)),
+    ds_ref  = ds$ref,
+    stringsAsFactors = FALSE
+  )
+}))
+ojs_define(table_ds_ref = table_ds_ref)
 # ojs_define(metadata = metadata)
 ```

--- a/_tbl-datasets.qmd
+++ b/_tbl-datasets.qmd
@@ -2,20 +2,32 @@
 redivis = require("redivis")
 redivis.authorize({ apiToken: "AAACU4CudFBM4Xf9jNnGda//my9ozSjZ" })
 
-dataset = await redivis
-  .user('datapages')
-  .dataset('item_response_warehouse')
+ds1 = await redivis.user('datapages').dataset('item_response_warehouse')
+ds2 = await redivis.user('datapages').dataset('item_response_warehouse_2')
+ds3 = await redivis.user('datapages').dataset('item_response_warehouse_3')
 
-tables = await dataset.listTables()
-dataset_names = await tables.map(t => t.name).filter(s => !s.startsWith('_')).sort()
+tables1 = await ds1.listTables()
+tables2 = await ds2.listTables()
+tables3 = await ds3.listTables()
+
+// Map table name → dataset object so row fetching hits the right source
+table_dataset_map = new Map([
+  ...tables1.map(t => [t.name, ds1]),
+  ...tables2.map(t => [t.name, ds2]),
+  ...tables3.map(t => [t.name, ds3])
+])
+
+dataset_names = [...new Set(
+  [...tables1, ...tables2, ...tables3]
+    .map(t => t.name)
+    .filter(s => !s.startsWith('_'))
+)].sort()
+
 datasets = new Map()
 
 async function getTable(tableName) {
-  const rows = await redivis
-    .user('datapages')
-    .dataset('item_response_warehouse')
-    .table(tableName)
-    .listRows({ maxResults: 10 })
+  const ds = table_dataset_map.get(tableName)
+  const rows = await ds.table(tableName).listRows({ maxResults: 10 })
   return rows
 }
 

--- a/data.qmd
+++ b/data.qmd
@@ -132,7 +132,9 @@ dataset_info = findDatasetInfo(dictionary, dataset_name);
 // Create the display elements with reference and BibTeX
 display = {
   const sanitizedDatasetName = dataset_name.replace(/\./g, "_"); // Replace all dots with underscores
-  const url = `https://redivis.com/embed/tables/datapages.item_response_warehouse:as2e:current.${sanitizedDatasetName}`;
+  const dsRefIdx = table_ds_ref.table.findIndex(t => t === dataset_name.toLowerCase());
+  const dsRef = dsRefIdx >= 0 ? table_ds_ref.ds_ref[dsRefIdx] : "item_response_warehouse:as2e";
+  const url = `https://redivis.com/embed/tables/datapages.${dsRef}:current.${sanitizedDatasetName}`;
   
   const container = html`<div>
     <div style="margin-bottom: 20px;">

--- a/renv.lock
+++ b/renv.lock
@@ -2556,7 +2556,7 @@
       "RemoteUsername": "itemresponsewarehouse",
       "RemoteRepo": "Rpkg",
       "RemoteRef": "main",
-      "RemoteSha": "5c936f6fac78fa908fb1fdce71f631f934cd193d",
+      "RemoteSha": "96d85c94114004cfe59d68e8f899efd62e092924",
       "Remotes": "redivis/redivis-r"
     },
     "isoband": {
@@ -4156,7 +4156,7 @@
     },
     "redivis": {
       "Package": "redivis",
-      "Version": "0.12.9",
+      "Version": "0.12.11",
       "Source": "GitHub",
       "Type": "Package",
       "Title": "R interface for Redivis",
@@ -4203,7 +4203,7 @@
       "RemoteUsername": "redivis",
       "RemoteRepo": "redivis-r",
       "RemoteRef": "main",
-      "RemoteSha": "ecd4486adecafa24f2079b95ac24bc4a16896e7c"
+      "RemoteSha": "8e6c3b8e523df539d741c76f2aaeb2fccfc78334"
     },
     "reformulas": {
       "Package": "reformulas",


### PR DESCRIPTION
## Summary

- Wires up the third IRW Redivis dataset (`item_response_warehouse_3:5xaj`) into the data explorer
- Updates `irw` R package to SHA `96d85c94` (\"adding third redivis dataset\")
- Updates `redivis` R package from 0.12.9 → 0.12.11

## Test plan

- [ ] Confirm data explorer loads all three IRW datasets
- [ ] Check `renv::restore()` succeeds cleanly on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)