### PR TITLE
Fix typo in identifier description in itemtext_merge.qmd

### DIFF
--- a/itemtext_merge.qmd
+++ b/itemtext_merge.qmd
@@ -5,7 +5,7 @@ title: "Merging item text and IRW response data"
 
 ## Incorporation with the IRW response data
 
-This dataset is designed to be interoperable with the core IRW item response data. Specifically, the `table` identifer should allow for merging across these two data resources. Researchers can link these item text records to response-level data using the `item` field, which serves as a shared, persistent identifier across both datasets.
+This dataset is designed to be interoperable with the core IRW item response data. Specifically, the `table` identifier should allow for merging across these two data resources. Researchers can link these item text records to response-level data using the `item` field, which serves as a shared, persistent identifier across both datasets.
 
 To incorporate response option text, the `resp` field in this dataset provides a mapping between response codes (consistent with `resp` in the response-level data) and their corresponding option_text. This allows users to reconstruct full item presentations or analyze response behavior with access to the literal item wording. Below is an example of how the data can be merged (so that each row contains information about a single response, including information about the probe used to solicit information from the respondent).
 


### PR DESCRIPTION
`"identifer" <- "identifier"`