### PR TITLE
Fix typo in identifier description in comps_standard.qmd

### DIFF
--- a/comps_standard.qmd
+++ b/comps_standard.qmd
@@ -6,7 +6,7 @@ Note: This is an experimental feature.
 
 ## The data standard
 
-The IRW competition data standard is meant to describe data derived from pairwise comparisons or competitions. Such data are widely analyzed using Elo or Bradley-Luce-Terry approaches; more information about these approaches is available [here](https://www.annualreviews.org/content/journals/10.1146/annurev-statistics-040722-061813). The key distinction between these data and the conventional IRW data is that there are not `id` and `item` identifiers here but rather identifers of the two `agents` that are involved in a given competition.
+The IRW competition data standard is meant to describe data derived from pairwise comparisons or competitions. Such data are widely analyzed using Elo or Bradley-Luce-Terry approaches; more information about these approaches is available [here](https://www.annualreviews.org/content/journals/10.1146/annurev-statistics-040722-061813). The key distinction between these data and the conventional IRW data is that there are not `id` and `item` identifiers here but rather identifiers of the two `agents` that are involved in a given competition.
 
 - `agent_a` name/id of first competitor
 - `agent_b` name/id of second competitor


### PR DESCRIPTION
`"identifers <- identifiers"`