### PR TITLE
Clarify instructions vs section_prompt boundary in item-text standard

### DIFF
--- a/itemtext.qmd
+++ b/itemtext.qmd
@@ -20,6 +20,8 @@ These data are structured as follows:
 
 - `section_prompt` This contains the literal text of a shared prompt, such as a reading passage, that applies to all items within a given `section_id`.
 
+- `instructions` and `section_prompt` are scoped differently: `instructions` applies to the entire table regardless of `section_id`; `section_prompt` applies only to the items sharing one or more specific `section_id` values. The same span of source text should never be recorded in both fields. If framing or task-level text applies across the whole table, record it once in `instructions`. If it is specific to a subset of items sharing a `section_id` (e.g. a passage or context given before a testlet), record it in `section_prompt` only, even if it superficially resembles instructional language.
+
 - `item_text` This is the literal text of the specific prompt or question associated with an `item`.
 
 - `correct_response` This is the scoring key for a given `item`. This field is left blank for items that do not have a correct response. For items with multiple correct answers, values are separated by a semicolon.


### PR DESCRIPTION
## Summary

An evaluation pilot found that the `instructions` and `section_prompt` fields in the item-text standard are applied inconsistently — both in existing human-curated data and in the extraction skill/pipeline that targets this standard — because the current definitions don't explicitly state the boundary between them.

This is a documentation-only clarification. It adds one new bullet to `itemtext.qmd`, immediately after the existing `section_prompt` definition and before `item_text`. The existing `instructions` and `section_prompt` definitions are unchanged.

New bullet, in full:

> `instructions` and `section_prompt` are scoped differently: `instructions` applies to the entire table regardless of `section_id`; `section_prompt` applies only to the items sharing one or more specific `section_id` values. The same span of source text should never be recorded in both fields. If framing or task-level text applies across the whole table, record it once in `instructions`. If it is specific to a subset of items sharing a `section_id` (e.g. a passage or context given before a testlet), record it in `section_prompt` only, even if it superficially resembles instructional language.

**No schema/column changes.** Existing data is not invalidated by this edit — it simply states a rule that future curation (human and automated) should follow going forward.

## Note for follow-up

A duplicated copy of these field definitions exists in `ben-domingue/irw` at `itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md` (the extraction skill this PR's clarification is meant to inform). That file is out of scope for this PR and needs a separate follow-up to bring it in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)